### PR TITLE
dev: WP as dev requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,12 +8,12 @@
     }
   },
   "require": {
-    "johnpbloch/wordpress": "5.2.*",
     "pimple/pimple": "^3.0",
     "psr/container": "1.*"
   },
   "require-dev": {
     "php": ">=7.1",
+    "johnpbloch/wordpress": "5.2.*",
     "php-coveralls/php-coveralls": "1.1.*",
     "phpstan/phpstan": "0.11.*",
     "phpunit/phpunit": "7.5.*|8.2.*",


### PR DESCRIPTION
WordPress is currently a requirement for this package.
By accident this got into the require section.
We shift this back to require-dev because we only need it for testing.