### PR TITLE
cli: Injecting WP-CLI commands the lazy way

### DIFF
--- a/lib/Provider/Services.php
+++ b/lib/Provider/Services.php
@@ -27,6 +27,7 @@ namespace RmpUp\WpDi\Provider;
 use Closure;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
+use RmpUp\WpDi\ServiceDefinition;
 
 /**
  * Setting "services" and "parameters".
@@ -83,26 +84,6 @@ class Services implements ServiceProviderInterface
             return;
         }
 
-        $this->compileArray($pimple, $serviceName, $definition);
-    }
-
-    /**
-     * @param Container $pimple
-     * @param string $serviceName
-     * @param array $definition
-     */
-    protected function compileArray(Container $pimple, string $serviceName, array $definition): void
-    {
-        $pimple[$serviceName] = static function ($pimple) use ($definition) {
-            $className = $definition[static::CLASS_NAME];
-
-            foreach ($definition[static::ARGUMENTS] as $key => $argument) {
-                if (is_string($argument) && isset($pimple[$argument])) {
-                    $definition[static::ARGUMENTS][$key] = $pimple[$argument];
-                }
-            }
-
-            return new $className(...array_values($definition[static::ARGUMENTS]));
-        };
+        $pimple[$serviceName] = new ServiceDefinition($definition);
     }
 }

--- a/lib/Provider/WordPress/CliCommands.php
+++ b/lib/Provider/WordPress/CliCommands.php
@@ -25,8 +25,9 @@ declare(strict_types=1);
 namespace RmpUp\WpDi\Provider\WordPress;
 
 use Pimple\Container;
-use Psr\Container\ContainerInterface;
+use ReflectionClass;
 use RmpUp\WpDi\LazyService;
+use RmpUp\WpDi\Provider\MissingServiceDefinitionException;
 use RmpUp\WpDi\Provider\Services;
 use WP_CLI;
 
@@ -57,6 +58,38 @@ class CliCommands extends Services
         $this->wpCliClass = $wpCliClass;
     }
 
+    /**
+     * @param array $definition
+     *
+     * @return mixed[]
+     * @throws \ReflectionException
+     */
+    private function createWpCliConfig($definition): array
+    {
+        $callable = (new ReflectionClass($definition[Services::CLASS_NAME]))->getMethod('__invoke');
+        $comment = (string) $callable->getDocComment();
+
+        if ('' === $comment) {
+            // There is no doc comment
+            return [];
+        }
+
+        $docParser = new WP_CLI\DocParser($comment);
+
+        $config = [
+            'shortdesc' => $docParser->get_shortdesc(),
+            'longdesc' => $docParser->get_longdesc(),
+            'synopsis' => $docParser->get_synopsis()
+        ];
+
+        $when = $docParser->get_tag('when');
+        if ($when) {
+            $config['when'] = $when;
+        }
+
+        return $config;
+    }
+
     public function register(Container $pimple): void
     {
         if ('cli' !== PHP_SAPI || !class_exists($this->wpCliClass)) {
@@ -64,41 +97,48 @@ class CliCommands extends Services
             return;
         }
 
-        $container = new \Pimple\Psr11\Container($pimple);
-
         foreach ($this->services as $serviceName => $service) {
             if (!array_key_exists(static::KEY, $service) || !is_string($serviceName)) {
                 continue;
             }
 
-            if (!$container->has($serviceName)) {
+            if (!$pimple->offsetExists($serviceName)) {
+                // Service config has not been loaded yet for this part.
                 $this->compile($pimple, $serviceName, $service);
             }
 
             if (array_key_exists(static::COMMAND, $service[static::KEY])) {
-                $this->addCommand($container, $serviceName, $service);
+                $this->addCommand($pimple, $serviceName, $service);
             }
         }
     }
 
-    private function addCommand(ContainerInterface $container, string $serviceName, array $definition): void
+    private function addCommand(Container $pimple, string $serviceName, array $definition): void
     {
+        $container = new \Pimple\Psr11\Container($pimple);
+
         $command = $definition[static::KEY][static::COMMAND];
         $class = $this->wpCliClass;
 
+        // Command points to a service
         if ($container->has($serviceName)) {
-            // Command is wired to existing service.
-            $class::add_command($command, $container->get($serviceName));
+            /** @noinspection PhpUndefinedMethodInspection */
+            $class::add_command(
+                $command,
+                new LazyService($container, $serviceName),
+                $this->createWpCliConfig($pimple->raw($serviceName))
+            );
+
             return;
         }
 
-        if (!$definition[Services::ARGUMENTS]) {
+        // Command points to a class
+        if (!$definition[Services::ARGUMENTS] && class_exists($definition[Services::CLASS_NAME])) {
             /** @noinspection PhpUndefinedMethodInspection */
             $class::add_command($command, $definition[Services::CLASS_NAME]);
             return;
         }
 
-        /** @noinspection PhpUndefinedMethodInspection */
-        $class::add_command($command, new LazyService($container, $serviceName));
+        throw new MissingServiceDefinitionException('Unknown service or class: ' . $serviceName);
     }
 }

--- a/lib/ServiceDefinition.php
+++ b/lib/ServiceDefinition.php
@@ -1,0 +1,59 @@
+<?php
+/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
+
+/**
+ * ServiceDefinition.php
+ *
+ * LICENSE: This source file is created by the company around M. Pretzlaw
+ * located in Germany also known as rmp-up. All its contents are proprietary
+ * and under german copyright law. Consider this file as closed source and/or
+ * without the permission to reuse or modify its contents.
+ * This license is available through the world-wide-web at the following URI:
+ * https://rmp-up.de/license-generic.txt . If you did not receive a copy
+ * of the license and are unable to obtain it through the web, please send a
+ * note to mail@rmp-up.de so we can mail you a copy.
+ *
+ * @package   wp-di
+ * @copyright 2020 Pretzlaw
+ * @license   https://rmp-up.de/license-generic.txt
+ */
+
+declare(strict_types=1);
+
+namespace RmpUp\WpDi;
+
+use ArrayObject;
+use Pimple\Container;
+use RmpUp\WpDi\Provider\Services;
+
+/**
+ * Carrying service definitions for late usage
+ *
+ * From defining a service to using it can be a long way
+ * or plenty lines of code.
+ * There are use cases (like for wp-cli) where the very early
+ * set service definition is needed later on.
+ *
+ * Usually you would give Pimple a closure that just creates the service/object.
+ * But this way all information about the definition would be gone.
+ * With the ServiceDefinition we carry the definition itself into Pimple
+ * and make it accessible for other services, compiler
+ * or provider (by using `Pimple::raw`).
+ *
+ * @copyright 2020 Pretzlaw (https://rmp-up.de)
+ */
+class ServiceDefinition extends ArrayObject
+{
+    public function __invoke(Container $pimple)
+    {
+        $className = $this[Services::CLASS_NAME];
+
+        foreach ($this[Services::ARGUMENTS] as $key => $argument) {
+            if (is_string($argument) && isset($pimple[$argument])) {
+                $this[Services::ARGUMENTS][$key] = $pimple[$argument];
+            }
+        }
+
+        return new $className(...array_values($this[Services::ARGUMENTS]));
+    }
+}

--- a/lib/Test/Provider/WpCli/Command/AsLazyServiceTest.php
+++ b/lib/Test/Provider/WpCli/Command/AsLazyServiceTest.php
@@ -36,7 +36,7 @@ use RmpUp\WpDi\Test\Mirror;
  * @copyright  2019 Mike Pretzlaw (https://mike-pretzlaw.de)
  * @since      2019-04-29
  */
-class NotAsLazyServiceTest extends AbstractTestCase
+class AsLazyServiceTest extends AbstractTestCase
 {
     private const SERVICE_NAME = 'someService';
     /**
@@ -63,7 +63,7 @@ class NotAsLazyServiceTest extends AbstractTestCase
 
     public function testIsLazyService()
     {
-        static::assertInstanceOf(Mirror::class, Mirror::$staticCalls[0]['arguments'][1]);
+        static::assertLazyService(self::SERVICE_NAME, Mirror::$staticCalls[0]['arguments'][1]);
     }
 
     public function testAddsCommand()

--- a/lib/Test/WordPress/Cli/SomeCliCommandHere.php
+++ b/lib/Test/WordPress/Cli/SomeCliCommandHere.php
@@ -1,0 +1,47 @@
+<?php
+/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
+
+/**
+ * StubDocComment.php
+ *
+ * LICENSE: This source file is created by the company around M. Pretzlaw
+ * located in Germany also known as rmp-up. All its contents are proprietary
+ * and under german copyright law. Consider this file as closed source and/or
+ * without the permission to reuse or modify its contents.
+ * This license is available through the world-wide-web at the following URI:
+ * https://rmp-up.de/license-generic.txt . If you did not receive a copy
+ * of the license and are unable to obtain it through the web, please send a
+ * note to mail@rmp-up.de so we can mail you a copy.
+ *
+ * @package   wp-di
+ * @copyright 2020 Pretzlaw
+ * @license   https://rmp-up.de/license-generic.txt
+ */
+
+declare(strict_types=1);
+
+use RmpUp\WpDi\Test\Mirror;
+
+/**
+ * StubDocComment
+ *
+ * @copyright 2020 Pretzlaw (https://rmp-up.de)
+ */
+class SomeCliCommandHere extends Mirror
+{
+    /**
+     * Prints a greeting.
+     *
+     * ## EXAMPLES
+     *
+     *     wp example hello Jerry
+     *
+     * @param mixed ...$invoked
+     *
+     * @return array
+     */
+    public function __invoke(...$invoked)
+    {
+        return parent::__invoke($invoked);
+    }
+}


### PR DESCRIPTION
Recently we forwarded compiled services to WP-CLI
so that it can parse the documentation.
This still has huge costs compared to forwarding
a proxy (LazyService).
For that we introduced a ServiceDefinition container
which carries the definition to decouple the documentation
from the actual callable later on.