### PR TITLE
cli: Define cli commands directly in service definition

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "phpstan/phpstan": "0.11.*",
     "phpunit/phpunit": "7.5.*|8.2.*",
     "pretzlaw/phpunit-docgen": "3.0.*",
-    "pretzlaw/wp-integration-test": "0.2.*",
+    "pretzlaw/wp-integration-test": "0.3.*",
     "roave/security-advisories": "dev-master",
     "squizlabs/php_codesniffer": "3.4.*",
     "wp-cli/config-command": "2.0.*",
@@ -30,5 +30,6 @@
   },
   "extra": {
     "wordpress-install-dir": "srv"
-  }
+  },
+  "minimum-stability": "dev"
 }

--- a/lib/Compiler.php
+++ b/lib/Compiler.php
@@ -1,0 +1,41 @@
+<?php
+/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
+
+/**
+ * Compiler.php
+ *
+ * LICENSE: This source file is created by the company around M. Pretzlaw
+ * located in Germany also known as rmp-up. All its contents are proprietary
+ * and under german copyright law. Consider this file as closed source and/or
+ * without the permission to reuse or modify its contents.
+ * This license is available through the world-wide-web at the following URI:
+ * https://rmp-up.de/license-generic.txt . If you did not receive a copy
+ * of the license and are unable to obtain it through the web, please send a
+ * note to mail@rmp-up.de so we can mail you a copy.
+ *
+ * @package   wp-di
+ * @copyright 2020 Pretzlaw
+ * @license   https://rmp-up.de/license-generic.txt
+ */
+
+declare(strict_types=1);
+
+namespace RmpUp\WpDi;
+
+/**
+ * Compiler
+ *
+ * @copyright 2020 Pretzlaw (https://rmp-up.de)
+ */
+class Compiler
+{
+    /**
+     * @var array
+     */
+    private $keyToCompiler;
+
+    public function __construct(array $keyToCompiler)
+    {
+        $this->keyToCompiler = $keyToCompiler;
+    }
+}

--- a/lib/Compiler/WpCli.php
+++ b/lib/Compiler/WpCli.php
@@ -1,0 +1,81 @@
+<?php
+/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
+
+/**
+ * WpCli.php
+ *
+ * LICENSE: This source file is created by the company around M. Pretzlaw
+ * located in Germany also known as rmp-up. All its contents are proprietary
+ * and under german copyright law. Consider this file as closed source and/or
+ * without the permission to reuse or modify its contents.
+ * This license is available through the world-wide-web at the following URI:
+ * https://rmp-up.de/license-generic.txt . If you did not receive a copy
+ * of the license and are unable to obtain it through the web, please send a
+ * note to mail@rmp-up.de so we can mail you a copy.
+ *
+ * @package   wp-di
+ * @copyright 2020 Pretzlaw
+ * @license   https://rmp-up.de/license-generic.txt
+ */
+
+declare(strict_types=1);
+
+namespace RmpUp\WpDi\Compiler;
+
+use Pimple\Container;
+use RmpUp\WpDi\LazyService;
+use RmpUp\WpDi\Provider\Services;
+
+/**
+ * WpCli
+ *
+ * @copyright 2020 Pretzlaw (https://rmp-up.de)
+ */
+class WpCli
+{
+    /**
+     * @var string
+     */
+    private $wpCliClass;
+
+    public function __construct($wpCliClass = null)
+    {
+        if (null === $wpCliClass) {
+            $wpCliClass = '\\WP_CLI';
+        }
+
+        $this->wpCliClass = $wpCliClass;
+    }
+
+    public function __invoke($commandToMethod, string $serviceName, Container $pimple)
+    {
+        if (is_scalar($commandToMethod)) {
+            $commandToMethod = [$commandToMethod => null];
+        }
+
+        $container = new \Pimple\Psr11\Container($pimple);
+
+        foreach ($commandToMethod as $command => $method) {
+            if (null === $method) {
+                $method = '__invoke';
+            }
+
+            $class = $this->wpCliClass;
+
+            $serviceDefinition = $pimple->raw($serviceName);
+
+            if (empty($serviceDefinition[Services::ARGUMENTS])) {
+                /** @noinspection PhpUndefinedMethodInspection */
+                $class::add_command($command, $serviceDefinition[Services::CLASS_NAME]);
+                continue;
+            }
+
+            if ($pimple->offsetExists($serviceName)) {
+                // Command is wired to existing service.
+                /** @noinspection PhpUndefinedMethodInspection */
+                $class::add_command($command, [new LazyService($container, $serviceName), $method]);
+                continue;
+            }
+        }
+    }
+}

--- a/lib/Provider/Services.php
+++ b/lib/Provider/Services.php
@@ -41,13 +41,25 @@ class Services implements ServiceProviderInterface
     public const ARGUMENTS = 'arguments';
 
     /**
+     * @var callable[][]
+     */
+    private $keywordToHandler;
+
+    /**
      * @var array
      */
     protected $services;
 
-    public function __construct(array $services)
+    /**
+     * Services constructor.
+     *
+     * @param array      $services
+     * @param callable[][] $keywordToHandler Mapping of keys delegating to other handler.
+     */
+    public function __construct(array $services, array $keywordToHandler = [])
     {
         $this->services = $services;
+        $this->keywordToHandler = $keywordToHandler;
     }
 
     /**

--- a/lib/Provider/WordPress/CliCommands.php
+++ b/lib/Provider/WordPress/CliCommands.php
@@ -36,6 +36,8 @@ use WP_CLI;
  *
  * @copyright  2019 Mike Pretzlaw (https://mike-pretzlaw.de)
  * @since      2019-06-12
+ *
+ * @deprecated 0.7.0 Define cli commands in the service directly.
  */
 class CliCommands extends Services
 {
@@ -49,6 +51,8 @@ class CliCommands extends Services
 
     public function __construct(array $services, string $wpCliClass = null)
     {
+        trigger_error('Use of ' . __CLASS__ . ' is deprecated', E_USER_DEPRECATED);
+
         parent::__construct($services);
 
         if (null === $wpCliClass) {

--- a/lib/Sanitizer/WordPress/CliCommands.php
+++ b/lib/Sanitizer/WordPress/CliCommands.php
@@ -31,11 +31,15 @@ use RmpUp\WpDi\Sanitizer\Services;
  *
  * @copyright  2019 Mike Pretzlaw (https://mike-pretzlaw.de)
  * @since      2019-06-12
+ *
+ * @deprecated 0.7.0 Define cli commands in the service directly.
  */
 class CliCommands extends Services
 {
     public function sanitize($node): array
     {
+        trigger_error('Use of ' . __CLASS__ . ' is deprecated', E_USER_DEPRECATED);
+
         $sanitized = [];
 
         foreach ($node as $serviceName => $serviceDefinition) {

--- a/lib/Test/AbstractTestCase.php
+++ b/lib/Test/AbstractTestCase.php
@@ -31,6 +31,7 @@ use Pretzlaw\PHPUnit\DocGen\DocComment\Parser;
 use ReflectionException;
 use ReflectionObject;
 use RmpUp\WpDi\LazyService;
+use Symfony\Component\Yaml\Yaml;
 
 /**
  * AbstractTestCase
@@ -106,5 +107,35 @@ abstract class AbstractTestCase extends TestCase
         static::$calls = [];
         static::$actions = [];
         Mirror::_reset();
+    }
+
+    protected function yaml($index = 0, ...$keys)
+    {
+        $allNodes = $this->classComment()->xpath('//code[@class="yaml"]');
+
+        if (!isset($allNodes[$index])) {
+            throw new \DomainException('Yaml example missing: ' . $index);
+        }
+
+        $data = Yaml::parse((string) $allNodes[$index]);
+
+        $path = [];
+        foreach ($keys as $key) {
+            $path[] = $key;
+
+            if (!array_key_exists($key, $data)) {
+                throw new \DomainException(
+                    sprintf(
+                        'Path "%s" does not exist in %d. Yaml example',
+                        implode('.', $path),
+                        $index
+                    )
+                );
+            }
+
+            $data = $data[$key];
+        }
+
+        return $data;
     }
 }

--- a/lib/Test/ProviderTestCase.php
+++ b/lib/Test/ProviderTestCase.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 
 namespace RmpUp\WpDi\Test;
 
+use RmpUp\WpDi\Provider;
 use RmpUp\WpDi\Test\Sanitizer\SanitizerTestCase;
 
 /**
@@ -34,5 +35,8 @@ use RmpUp\WpDi\Test\Sanitizer\SanitizerTestCase;
  */
 abstract class ProviderTestCase extends SanitizerTestCase
 {
+    /**
+     * @var Provider
+     */
     protected $provider;
 }

--- a/lib/Test/WordPress/Cli/ServiceDefinitionTest.php
+++ b/lib/Test/WordPress/Cli/ServiceDefinitionTest.php
@@ -1,0 +1,121 @@
+<?php
+/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
+
+/**
+ * ServiceDefinitionTest.php
+ *
+ * LICENSE: This source file is created by the company around M. Pretzlaw
+ * located in Germany also known as rmp-up. All its contents are proprietary
+ * and under german copyright law. Consider this file as closed source and/or
+ * without the permission to reuse or modify its contents.
+ * This license is available through the world-wide-web at the following URI:
+ * https://rmp-up.de/license-generic.txt . If you did not receive a copy
+ * of the license and are unable to obtain it through the web, please send a
+ * note to mail@rmp-up.de so we can mail you a copy.
+ *
+ * @package   wp-di
+ * @copyright 2020 Pretzlaw
+ * @license   https://rmp-up.de/license-generic.txt
+ */
+
+declare(strict_types=1);
+
+namespace RmpUp\WpDi\Test\WordPress\Cli;
+
+use Pimple\Container;
+use RmpUp\WpDi\Provider;
+use RmpUp\WpDi\Provider\WordPress\CliCommands;
+use RmpUp\WpDi\Test\AbstractTestCase;
+use RmpUp\WpDi\Test\Mirror;
+use RmpUp\WpDi\Test\ProviderTestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * WP-CLI commands in service definition
+ *
+ * CLI commands can be defined while defining the service:
+ *
+ * ```yaml
+ * services:
+ *   MyOwnCliCommand:
+ *     wp_cli: hello neighbour
+ * ```
+ *
+ * This is the shortest form which will add the command "hello neighbour" in WP-CLI.
+ * WP-CLI itself should delegate the execution to `MyOwnCliCommand::__invoke` as usual.
+ *
+ * Allowing one class to handle multiple commands can be defined like this:
+ *
+ * ```yaml
+ * services:
+ *   MyOwnCliCommand:
+ *     arguments:
+ *       - 3.14159
+ *       - 'Hello World!'
+ *     wp_cli:
+ *       hello neighbour: ~
+ *       hello world: terra
+ *       hello upstairs: __invoke
+ * ```
+ *
+ * In this example the service/class `MyOwnCliCommand` handles three CLI commands:
+ *
+ * 1. `wp hello neighbour`
+ * 2. `wp hello world`
+ * 3. `wp hello upstairs`
+ *
+ * The first one will execute the method `MyOwnCliCommand::__invoke()`
+ * and the second one will make use of `MyOwnCliCommand::world()`.
+ * With that it is possible to define multiple CLI commands in one class
+ * or create aliases just like "hello upstairs" which is not different from
+ * "hello neighbour" as it points to the same method
+ * (`MyOwnCliCommand::__invoke()`).
+ *
+ * @copyright 2020 Pretzlaw (https://rmp-up.de)
+ */
+class ServiceDefinitionTest extends ProviderTestCase
+{
+    /**
+     * @var array
+     */
+    private $config;
+
+    /**
+     * @param $arguments
+     * @param $name
+     */
+    private function assertCommandRegistered($name, $method, $arguments)
+    {
+        static::assertEquals($name, $arguments[0]);
+        static::assertIsArray($arguments[1]);
+        static::assertLazyService('MyOwnCliCommand', $arguments[1][0]);
+        static::assertSame($method, $arguments[1][1]);
+    }
+
+    public function testShortCliCommandSyntax()
+    {
+        $this->config = [Provider\Services::class => $this->yaml(0, 'services')];
+
+        $this->provider = new Provider($this->config);
+        $this->provider->register($this->pimple);
+
+        $history = \WP_CLI::_history('add_command');
+
+        $this->assertCount(1, $history);
+        $this->assertCommandRegistered('hello neighbour', '__invoke', $history[0]['arguments']);
+    }
+
+    public function testLongCliCommandSyntax()
+    {
+        $this->config = [Provider\Services::class => $this->yaml(1, 'services')];
+
+        $this->provider = new Provider($this->config);
+        $this->provider->register($this->pimple);
+
+        $history = \WP_CLI::_history('add_command');
+
+        $this->assertCommandRegistered('hello neighbour', '__invoke', $history[0]['arguments']);
+        $this->assertCommandRegistered('hello world', 'terra', $history[1]['arguments']);
+        $this->assertCommandRegistered('hello upstairs', '__invoke', $history[2]['arguments']);
+    }
+}

--- a/lib/Test/bootstrap.php
+++ b/lib/Test/bootstrap.php
@@ -8,4 +8,7 @@ class_alias(Mirror::class, '\\SomeThing');
 class_alias(Mirror::class, '\\MyOwnCliCommand');
 class_alias(Mirror::class, '\\WP_CLI');
 
+// Tell wp-integration-test where to find WP
+$_ENV['WP_DIR'] = $_ENV['WP_DIR'] ?: dirname(__DIR__, 2) . '/srv/';
+
 require_once __DIR__ . '/../../vendor/pretzlaw/wp-integration-test/bootstrap.php';

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,6 +3,7 @@
          backupGlobals="false"
          colors="true"
          bootstrap="lib/Test/bootstrap.php"
+         convertDeprecationsToExceptions="false"
 >
     <testsuites>
         <testsuite name="default">


### PR DESCRIPTION
Common sense is that everything gets defined
in the "service" section of a DI-config.
By now we are using multiple sections to divide concerns
like "CliCommands", "Templates" etc.
We began merging CLI commands into the service definition.