### PR TITLE
filter: Define actions/filter commands directly in service definition

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2019 Mike Pretzlaw
+Copyright (c) 2020 M. Pretzlaw
 
 Permission is hereby granted, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -60,14 +60,14 @@ return [
     Parameters::class => [
         'some' => 'primitives',
         'like' => 42,
-    ]
+    ],
     
     Services::class => [
         Something::class => [
             'like' // injecting the parameter here
         ]
-    ]
-]
+    ],
+];
 ```
 
 
@@ -81,7 +81,7 @@ return [
         'company' => \My\PostType\Company::class,
         'wolves' => \My\PostType\Wolves::class,
     ]
-]
+];
 ```
 
 Such classes will be cast to array
@@ -90,18 +90,16 @@ and used for `register_post_type()`.
 
 ### Actions
 
-Registering actions can be kept that simple too
-and gets tricky if you need argument count and priorities:
+Registering actions can be kept that simple too. Write ...
 
-```php
-return [
-    'init' => [
-        InitPlugin::class,
-    ],
-]
+```yaml
+services:
+  Tribute\BestPluginInTheWorld\Rock:
+    add_action: init
 ```
 
-Add a service "InitPlugin" which is invoked when the init-action occurs.
+... to add a service for the class `\Tribute\BestPluginInTheWorld\Rock`
+which is invoked when the "init"-action occurs.
 
 
 ### And more

--- a/lib/Compiler/CompilerInterface.php
+++ b/lib/Compiler/CompilerInterface.php
@@ -1,0 +1,35 @@
+<?php
+/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
+
+/**
+ * CompilerInterface.php
+ *
+ * LICENSE: This source file is created by the company around M. Pretzlaw
+ * located in Germany also known as rmp-up. All its contents are proprietary
+ * and under german copyright law. Consider this file as closed source and/or
+ * without the permission to reuse or modify its contents.
+ * This license is available through the world-wide-web at the following URI:
+ * https://rmp-up.de/license-generic.txt . If you did not receive a copy
+ * of the license and are unable to obtain it through the web, please send a
+ * note to mail@rmp-up.de so we can mail you a copy.
+ *
+ * @package   wp-di
+ * @copyright 2020 Pretzlaw
+ * @license   https://rmp-up.de/license-generic.txt
+ */
+
+declare(strict_types=1);
+
+namespace RmpUp\WpDi\Compiler;
+
+use Pimple\Container;
+
+/**
+ * CompilerInterface
+ *
+ * @copyright 2020 Pretzlaw (https://rmp-up.de)
+ */
+interface CompilerInterface
+{
+    public function __invoke($definition, string $serviceName, Container $pimple);
+}

--- a/lib/Compiler/Filter.php
+++ b/lib/Compiler/Filter.php
@@ -1,0 +1,92 @@
+<?php
+/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
+
+/**
+ * Actions.php
+ *
+ * LICENSE: This source file is created by the company around M. Pretzlaw
+ * located in Germany also known as rmp-up. All its contents are proprietary
+ * and under german copyright law. Consider this file as closed source and/or
+ * without the permission to reuse or modify its contents.
+ * This license is available through the world-wide-web at the following URI:
+ * https://rmp-up.de/license-generic.txt . If you did not receive a copy
+ * of the license and are unable to obtain it through the web, please send a
+ * note to mail@rmp-up.de so we can mail you a copy.
+ *
+ * @package   wp-di
+ * @copyright 2020 Pretzlaw
+ * @license   https://rmp-up.de/license-generic.txt
+ */
+
+declare(strict_types=1);
+
+namespace RmpUp\WpDi\Compiler;
+
+use Pimple\Container;
+use RmpUp\WpDi\LazyService;
+
+/**
+ * Filter
+ *
+ * @copyright 2020 Pretzlaw (https://rmp-up.de)
+ */
+class Filter implements CompilerInterface
+{
+    const DEFAULT_PRIORITY = 10;
+    /**
+     * @var string
+     */
+    private $defaultMethod;
+    /**
+     * @var int
+     */
+    private $defaultPriority;
+
+    public function __construct(int $defaultPriority = 10, string $defaultMethod = '__invoke')
+    {
+        $this->defaultPriority = $defaultPriority;
+        $this->defaultMethod = $defaultMethod;
+    }
+
+    public function __invoke($definition, string $serviceName, Container $pimple)
+    {
+        $definition = $this->sanitize($definition);
+
+        $container = new \Pimple\Psr11\Container($pimple);
+        foreach ($definition as $filterName => $prioToCallback) {
+            foreach ($prioToCallback as $priority => $methodName) {
+                add_filter(
+                    $filterName,
+                    [new LazyService($container, $serviceName), $methodName],
+                    $priority,
+                    PHP_INT_MAX
+                );
+            }
+        }
+    }
+
+    private function sanitize($definition)
+    {
+        if (is_scalar($definition)) {
+            $definition = [$definition => null];
+        }
+
+        foreach ($definition as $filterName => $prioToCallback) {
+            if (null === $prioToCallback) {
+                $prioToCallback = [
+                    $this->defaultPriority => $this->defaultMethod,
+                ];
+            }
+
+            if (is_scalar($prioToCallback)) {
+                $prioToCallback = [
+                    $this->defaultPriority => $prioToCallback
+                ];
+            }
+
+            $definition[$filterName] = $prioToCallback;
+        }
+
+        return $definition;
+    }
+}

--- a/lib/Compiler/WpCli.php
+++ b/lib/Compiler/WpCli.php
@@ -31,7 +31,7 @@ use RmpUp\WpDi\Provider\Services;
  *
  * @copyright 2020 Pretzlaw (https://rmp-up.de)
  */
-class WpCli
+class WpCli implements CompilerInterface
 {
     /**
      * @var string

--- a/lib/Provider.php
+++ b/lib/Provider.php
@@ -27,6 +27,7 @@ namespace RmpUp\WpDi;
 use InvalidArgumentException;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
+use RmpUp\WpDi\Compiler\Filter;
 use RmpUp\WpDi\Compiler\WpCli;
 use RmpUp\WpDi\Provider\Services;
 use RmpUp\WpDi\Sanitizer\SanitizerInterface;
@@ -77,7 +78,15 @@ class Provider implements ServiceProviderInterface
         $this->sanitizer = $sanitizer;
 
         if ([] === $keyToCompiler) {
-            $keyToCompiler['wp_cli'] = [new WpCli()];
+            $filter = [new Filter()];
+
+            $keyToCompiler = [
+                'add_filter' => $filter,
+                'filter' => $filter,
+                'add_action' => $filter,
+                'action' => $filter,
+                'wp_cli' => [new WpCli()]
+            ];
         }
 
         $this->keyToCompiler = $keyToCompiler;
@@ -134,7 +143,6 @@ class Provider implements ServiceProviderInterface
                         $extension($serviceDefinition[$key], $serviceName, $pimple);
                     }
                 }
-
             }
         }
     }

--- a/lib/Provider/WordPress/Actions.php
+++ b/lib/Provider/WordPress/Actions.php
@@ -34,8 +34,8 @@ use RmpUp\WpDi\Provider\Services;
 /**
  * Providing action hooks to pimple
  *
- * @copyright  2019 Mike Pretzlaw (https://mike-pretzlaw.de)
- * @since      2019-04-25
+ * @copyright  2020 Pretzlaw (https://rmp-up.de)
+ * @deprecated 0.7.0 Use \RmpUp\WpDi\Compiler\Filter instead.
  */
 class Actions extends Services
 {

--- a/lib/Sanitizer/WordPress/Actions.php
+++ b/lib/Sanitizer/WordPress/Actions.php
@@ -30,8 +30,8 @@ use RmpUp\WpDi\Provider\WordPress\Actions as Provider;
 /**
  * Sanitize action definitions
  *
- * @copyright  2019 Mike Pretzlaw (https://mike-pretzlaw.de)
- * @since      2019-04-26
+ * @copyright  2020 Pretzlaw (https://rmp-up.de)
+ * @deprecated 0.7.0 Use \RmpUp\WpDi\Compiler\Filter instead.
  */
 class Actions extends Services
 {

--- a/lib/Test/AbstractTestCase.php
+++ b/lib/Test/AbstractTestCase.php
@@ -28,6 +28,7 @@ use Closure;
 use PHPUnit\Framework\TestCase;
 use Pimple\Container;
 use Pretzlaw\PHPUnit\DocGen\DocComment\Parser;
+use Pretzlaw\WPInt\Traits\WordPressTests;
 use ReflectionException;
 use ReflectionObject;
 use RmpUp\WpDi\LazyService;
@@ -42,6 +43,7 @@ use Symfony\Component\Yaml\Yaml;
 abstract class AbstractTestCase extends TestCase
 {
     use Parser;
+    use WordPressTests;
 
     /**
      * @var Container
@@ -77,6 +79,18 @@ abstract class AbstractTestCase extends TestCase
         }
 
         return null;
+    }
+
+    /**
+     * @param string $filterName
+     *
+     * @return \WP_Hook|null
+     */
+    protected function getFilter(string $filterName)
+    {
+        global $wp_filter;
+
+        return $wp_filter[$filterName] ?? null;
     }
 
     protected static function assertLazyService(string $serviceName, $lazyServiceObject)

--- a/lib/Test/WordPress/Actions/Definition/ServiceDefinitionTest.php
+++ b/lib/Test/WordPress/Actions/Definition/ServiceDefinitionTest.php
@@ -24,6 +24,9 @@ declare(strict_types=1);
 
 namespace RmpUp\WpDi\Test\WordPress\Actions\Definition;
 
+use MyOwnActionListener;
+use MyOwnFilterHandler;
+use RmpUp\WpDi\Provider\Services;
 use RmpUp\WpDi\Provider\WordPress\Actions as Provider;
 use RmpUp\WpDi\Sanitizer\WordPress\Actions;
 use RmpUp\WpDi\Test\Mirror;
@@ -32,7 +35,66 @@ use RmpUp\WpDi\Test\Sanitizer\SanitizerTestCase;
 /**
  * Direct service definition at once
  *
- * One way to bind a service to the action is
+ * To bind a service to an action or filter can be done using common keywords:
+ *
+ * ```yaml
+ * services:
+ *   MyOwnFilterHandler:
+ *     add_filter: the_content
+ * ```
+ *
+ * Which is already the shortest possible definition.
+ * This way an instance of the `MyOwnFilterHandler` class
+ * will be registered as a service.
+ * When the "the_content" filter runs in WordPress
+ * then it would call the `MyOwnFilterHandler::__invoke` method of the object.
+ *
+ * When the service/object is needed for multiple filter/actions
+ * then we go in detail after "add_action"/"add_filter" like this:
+ *
+ * ```yaml
+ * services:
+ *   MyOwnActionListener:
+ *     add_action:
+ *       personal_options_update: ~
+ *       edit_user_profile_update: ~
+ *       user_edit_form_tag: editFormTag
+ * ```
+ *
+ * Now the two actions "personal_options_update"
+ * and "edit_user_profile_update" would both run the
+ * `MyOwnActionListener::__invoke` method.
+ * But the third action ("user_edit_form_tag") would register
+ * `MyOwnActionListener::editFormTag` (with the default priority of 10).
+ *
+ * Internally the above configs will be extended to a more complete config
+ * which also allows to change the priority:
+ *
+ * ```yaml
+ * services:
+ *   MyOwnFilterHandler:
+ *     filter:
+ *      the_content:
+ *        10: __invoke
+ *
+ *   MyOwnActionListener:
+ *     action:
+ *       personal_options_update:
+ *         10: __invoke
+ *       edit_user_profile_update:
+ *         42: someOtherMethod
+ * ```
+ *
+ * Writing such a complete definition allows to change the priority.
+ * Besides the keywords "action"
+ * and "filter" are valid aliases for "add_action"
+ * and "add_filter".
+ *
+ * Note: The above examples do not need to tell how many arguments are needed.
+ * The DI will take care of this as it just passes any given argument
+ * and leaves the correct handling to PHP.
+ *
+ * A more deprecated way to bind a service to the action is
  * to directly define it within the actions part:
  *
  * ```php
@@ -60,11 +122,31 @@ use RmpUp\WpDi\Test\Sanitizer\SanitizerTestCase;
  */
 class ServiceDefinitionTest extends SanitizerTestCase
 {
+    private function assertLazyFilterRegistered($filterName, $serviceName, $method = '__invoke', $priority = 10)
+    {
+        self::assertActionNotEmpty($filterName);
+        $filter = current($this->getFilter($filterName)->callbacks[$priority]);
+        self::assertLazyService($serviceName, $filter['function'][0]);
+        self::assertSame($method, $filter['function'][1]);
+    }
+
     protected function setUp()
     {
         parent::setUp();
 
         $this->sanitizer = new Actions();
+
+        remove_all_filters('the_content');
+        $this->assertActionEmpty('the_content');
+
+        remove_all_actions('personal_options_update');
+        $this->assertActionEmpty('personal_options_update');
+
+        remove_all_actions('edit_user_profile_update');
+        $this->assertActionEmpty('edit_user_profile_update');
+
+        remove_all_actions('user_edit_form_tag');
+        $this->assertActionEmpty('user_edit_form_tag');
     }
 
     public function testExtendsClassNameToAction()
@@ -73,14 +155,14 @@ class ServiceDefinitionTest extends SanitizerTestCase
             [
                 'foo' => [
                     [
-	                    Provider::SERVICE   => [
+                        Provider::SERVICE => [
                             Mirror::class => [
-	                            Provider::CLASS_NAME => Mirror::class,
-	                            Provider::ARGUMENTS  => [],
+                                Provider::CLASS_NAME => Mirror::class,
+                                Provider::ARGUMENTS => [],
                             ]
                         ],
-	                    Provider::PRIORITY  => 10,
-	                    Provider::ARG_COUNT => 1,
+                        Provider::PRIORITY => 10,
+                        Provider::ARG_COUNT => 1,
                     ]
                 ]
             ],
@@ -89,6 +171,53 @@ class ServiceDefinitionTest extends SanitizerTestCase
                     Mirror::class
                 ]
             ])
+        );
+    }
+
+    public function testShortFilterDefinition()
+    {
+        $this->pimple->register(
+            new \RmpUp\WpDi\Provider(
+                [
+                    Services::class => $this->yaml(0, 'services')
+                ]
+            )
+        );
+
+        $this->assertLazyFilterRegistered('the_content', MyOwnFilterHandler::class);
+    }
+
+    public function testMultipleFilterDefinition()
+    {
+        $this->pimple->register(
+            new \RmpUp\WpDi\Provider(
+                [
+                    Services::class => $this->yaml(1, 'services')
+                ]
+            )
+        );
+
+        $this->assertLazyFilterRegistered('personal_options_update', MyOwnActionListener::class);
+        $this->assertLazyFilterRegistered('edit_user_profile_update', MyOwnActionListener::class);
+        $this->assertLazyFilterRegistered('user_edit_form_tag', MyOwnActionListener::class, 'editFormTag');
+    }
+
+    public function testCompleteFilterDefinition()
+    {
+        $this->pimple->register(
+            new \RmpUp\WpDi\Provider(
+                [
+                    Services::class => $this->yaml(2, 'services')
+                ]
+            )
+        );
+
+        $this->assertLazyFilterRegistered('personal_options_update', MyOwnActionListener::class);
+        $this->assertLazyFilterRegistered(
+            'edit_user_profile_update',
+            MyOwnActionListener::class,
+            'someOtherMethod',
+            42
         );
     }
 }

--- a/lib/Test/bootstrap.php
+++ b/lib/Test/bootstrap.php
@@ -6,6 +6,8 @@ const MY_PLUGIN_DIR = __DIR__;
 
 class_alias(Mirror::class, '\\SomeThing');
 class_alias(Mirror::class, '\\MyOwnCliCommand');
+class_alias(Mirror::class, '\\MyOwnFilterHandler');
+class_alias(Mirror::class, '\\MyOwnActionListener');
 class_alias(Mirror::class, '\\WP_CLI');
 
 // Tell wp-integration-test where to find WP


### PR DESCRIPTION
Common sense is that everything gets defined
in the "service" section of a DI-config.
By now we are using multiple sections to divide concerns
like "Actions", "Filter", "Templates" etc.
After CLI commands we now also allow defining action-
and filter-registrations within the service definition.