### PR TITLE
services: Service provider now manages keywords

### DIFF
--- a/lib/Compiler/Filter.php
+++ b/lib/Compiler/Filter.php
@@ -26,13 +26,18 @@ use Pimple\Container;
 use RmpUp\WpDi\LazyService;
 
 /**
- * Filter
+ * Filter or action
  *
  * @copyright 2020 Pretzlaw (https://rmp-up.de)
  */
 class Filter implements CompilerInterface
 {
-    const DEFAULT_PRIORITY = 10;
+    /** @var string Key to use in service definitions (to indicate a filter) */
+    const FILTER_KEY = 'filter';
+
+    /** @var string Key to use in service definitions (to indicate an action)  */
+    const ACTION_KEY = 'action';
+
     /**
      * @var string
      */

--- a/lib/Compiler/WpCli.php
+++ b/lib/Compiler/WpCli.php
@@ -25,6 +25,7 @@ namespace RmpUp\WpDi\Compiler;
 use Pimple\Container;
 use RmpUp\WpDi\LazyService;
 use RmpUp\WpDi\Provider\Services;
+use RmpUp\WpDi\Provider\WordPress\CliCommands;
 
 /**
  * WpCli
@@ -49,6 +50,11 @@ class WpCli implements CompilerInterface
 
     public function __invoke($commandToMethod, string $serviceName, Container $pimple)
     {
+        if (is_array($commandToMethod) && array_key_exists(CliCommands::COMMAND, $commandToMethod)) {
+            // DEPRECATED 0.6 structure will be ignored
+            return;
+        }
+
         if (is_scalar($commandToMethod)) {
             $commandToMethod = [$commandToMethod => null];
         }

--- a/lib/Sanitizer/Services.php
+++ b/lib/Sanitizer/Services.php
@@ -69,8 +69,11 @@ class Services implements SanitizerInterface
             }
 
             if (is_array($definition) && !array_key_exists(ServicesProvider::CLASS_NAME, $definition)) {
+                // DEPRECATED 0.7 - following IF is BC for very abbreviated service definitions via PHP
                 if (!array_key_exists(ServicesProvider::ARGUMENTS, $definition)) {
-                    $definition = [ServicesProvider::ARGUMENTS => $definition];
+                    $arguments = array_filter($definition, 'is_int', ARRAY_FILTER_USE_KEY);
+                    $definition = array_filter($definition, 'is_string', ARRAY_FILTER_USE_KEY);
+                    $definition[ServicesProvider::ARGUMENTS] = $arguments;
                 }
 
                 $definition[ServicesProvider::CLASS_NAME] = $id;

--- a/lib/Test/WordPress/Actions/Definition/ServiceDefinitionTest.php
+++ b/lib/Test/WordPress/Actions/Definition/ServiceDefinitionTest.php
@@ -130,6 +130,34 @@ class ServiceDefinitionTest extends SanitizerTestCase
         self::assertSame($method, $filter['function'][1]);
     }
 
+    public function getCompleteDefinition(): array
+    {
+        return [
+            'v0.6' => [ // DEPRECATED
+                [
+                    Services::class => $this->yaml(2, 'services')
+                ]
+            ],
+            'v0.7' => [
+                $this->yaml(2)
+            ],
+        ];
+    }
+
+    public function getMultipleFilterDefinition(): array
+    {
+        return [
+            '0.6' => [
+                [
+                    Services::class => $this->yaml(1, 'services')
+                ]
+            ],
+            '0.7' => [
+                $this->yaml(1)
+            ]
+        ];
+    }
+
     protected function setUp()
     {
         parent::setUp();
@@ -187,29 +215,25 @@ class ServiceDefinitionTest extends SanitizerTestCase
         $this->assertLazyFilterRegistered('the_content', MyOwnFilterHandler::class);
     }
 
-    public function testMultipleFilterDefinition()
+    /**
+     * @dataProvider getMultipleFilterDefinition
+     */
+    public function testMultipleFilterDefinition($config)
     {
-        $this->pimple->register(
-            new \RmpUp\WpDi\Provider(
-                [
-                    Services::class => $this->yaml(1, 'services')
-                ]
-            )
-        );
+        $this->pimple->register(new \RmpUp\WpDi\Provider($config));
 
         $this->assertLazyFilterRegistered('personal_options_update', MyOwnActionListener::class);
         $this->assertLazyFilterRegistered('edit_user_profile_update', MyOwnActionListener::class);
         $this->assertLazyFilterRegistered('user_edit_form_tag', MyOwnActionListener::class, 'editFormTag');
     }
 
-    public function testCompleteFilterDefinition()
+    /**
+     * @dataProvider getCompleteDefinition
+     */
+    public function testCompleteFilterDefinition($definition)
     {
         $this->pimple->register(
-            new \RmpUp\WpDi\Provider(
-                [
-                    Services::class => $this->yaml(2, 'services')
-                ]
-            )
+            new \RmpUp\WpDi\Provider($definition)
         );
 
         $this->assertLazyFilterRegistered('personal_options_update', MyOwnActionListener::class);


### PR DESCRIPTION
Defining actions, cli commands and other things
within the scope of the service definition
is implemented step by step into the system.
While the provider adapt (and become compiler)
the main provider is not able to handle a complete
set of definitions with the new keywords
(as in an PHP- or YAML-File).
With this commit the main Provider now knows
how to delegate each section to the appropriate
provider or compiler.