### PR TITLE
templates: Register templates using YAML

### DIFF
--- a/lib/Provider.php
+++ b/lib/Provider.php
@@ -29,6 +29,7 @@ use Pimple\Container;
 use Pimple\ServiceProviderInterface;
 use RmpUp\WpDi\Provider\Parameters;
 use RmpUp\WpDi\Provider\Services;
+use RmpUp\WpDi\Provider\WordPress\Templates;
 use RmpUp\WpDi\Sanitizer\SanitizerInterface;
 
 /**
@@ -92,6 +93,7 @@ class Provider implements ServiceProviderInterface
         return [
             'services' => Services::class,
             'parameters' => Parameters::class,
+            'templates' => Templates::class,
         ];
     }
 

--- a/lib/Provider/WordPress/Templates.php
+++ b/lib/Provider/WordPress/Templates.php
@@ -27,6 +27,7 @@ namespace RmpUp\WpDi\Provider\WordPress;
 use Closure;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
+use RmpUp\WpDi\ServiceDefinition\TemplateNode;
 
 /**
  * Templates
@@ -70,24 +71,7 @@ class Templates implements ServiceProviderInterface
                 continue;
             }
 
-            $pimple[$serviceName] = static function () use ($templates) {
-                $templatePath = '';
-
-                foreach ($templates as $templatePath) {
-                    $located = locate_template($templatePath, false, false);
-
-                    if ('' !== $located) {
-                        return $located;
-                    }
-
-                    if (file_exists($templatePath)) {
-                        return $templatePath;
-                    }
-                }
-
-                // In doubt return the very last entry
-                return $templatePath;
-            };
+            $pimple[$serviceName] = new TemplateNode($templates);
         }
     }
 }

--- a/lib/ServiceDefinition/TemplateNode.php
+++ b/lib/ServiceDefinition/TemplateNode.php
@@ -1,0 +1,80 @@
+<?php
+/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
+
+/**
+ * TemplateNode.php
+ *
+ * LICENSE: This source file is created by the company around M. Pretzlaw
+ * located in Germany also known as rmp-up. All its contents are proprietary
+ * and under german copyright law. Consider this file as closed source and/or
+ * without the permission to reuse or modify its contents.
+ * This license is available through the world-wide-web at the following URI:
+ * https://rmp-up.de/license-generic.txt . If you did not receive a copy
+ * of the license and are unable to obtain it through the web, please send a
+ * note to mail@rmp-up.de so we can mail you a copy.
+ *
+ * @package   wp-di
+ * @copyright 2020 Pretzlaw
+ * @license   https://rmp-up.de/license-generic.txt
+ */
+
+declare(strict_types=1);
+
+namespace RmpUp\WpDi\ServiceDefinition;
+
+/**
+ * TemplateNode
+ *
+ * @copyright 2020 Pretzlaw (https://rmp-up.de)
+ */
+class TemplateNode
+{
+    /**
+     * All possible locations
+     *
+     * @var array
+     */
+    private $templates;
+
+    /**
+     * Caching to spare costs.
+     * @var string
+     */
+    private $resolvedPath;
+
+    public function __construct(array $templates)
+    {
+        $this->templates = $templates;
+    }
+
+    public function __invoke(): string
+    {
+        if (null === $this->resolvedPath) {
+            $this->resolve();
+        }
+
+        return $this->resolvedPath;
+    }
+
+    private function resolve()
+    {
+        $this->resolvedPath = '';
+
+        foreach ($this->templates as $templatePath) {
+            $located = locate_template($templatePath, false, false);
+
+            if ('' !== $located) {
+                $this->resolvedPath = $located;
+                return;
+            }
+
+            if (file_exists($templatePath)) {
+                $this->resolvedPath = $templatePath;
+                return;
+            }
+        }
+
+        // In doubt use the very last entry
+        $this->resolvedPath = $templatePath;
+    }
+}

--- a/lib/Test/WordPress/PostTypes/Provider/PostTypeDefinitionAsArrayTest.php
+++ b/lib/Test/WordPress/PostTypes/Provider/PostTypeDefinitionAsArrayTest.php
@@ -89,4 +89,16 @@ class PostTypeDefinitionAsArrayTest extends AbstractTestCase
             new IsEqual(new RegisterPostType($this->container, 'some_type', 'some_type'))
         );
     }
+
+
+    public function testPostTypeIsRegistered()
+    {
+        $this->pimple->register($this->provider);
+
+        $postType = 'some_type';
+
+        static::assertFalse(post_type_exists($postType));
+        (new RegisterPostType($this->container, 'some_type', 'some_type'))();
+        static::assertTrue(post_type_exists($postType));
+    }
 }

--- a/lib/Test/WordPress/PostTypes/Provider/PostTypeDefinitionAsCallableTest.php
+++ b/lib/Test/WordPress/PostTypes/Provider/PostTypeDefinitionAsCallableTest.php
@@ -111,4 +111,13 @@ class PostTypeDefinitionAsCallableTest extends AbstractTestCase
             new IsEqual(new RegisterPostType($this->container, 'callable_type', 'callable_type'))
         );
     }
+
+    public function testPostTypeIsRegistered()
+    {
+        $this->pimple->register($this->provider);
+
+        static::assertFalse(post_type_exists('callable_type'));
+        (new RegisterPostType($this->container, 'callable_type', 'callable_type'))('callable_type');
+        static::assertTrue(post_type_exists('callable_type'));
+    }
 }

--- a/lib/Test/WordPress/Templates/TemplatesTestCase.php
+++ b/lib/Test/WordPress/Templates/TemplatesTestCase.php
@@ -63,9 +63,9 @@ abstract class TemplatesTestCase extends ProviderTestCase
         static::assertEquals(ABSPATH . WPINC . '/theme-compat/' . trim($expectedWithoutWpinc, '/'), $current);
     }
 
-    protected function stubTemplateFile(string $fileName): void
+    protected function stubTemplateFile(string $fileName): string
     {
-        $fullPath = ABSPATH . WPINC . '/theme-compat/' . trim($fileName, '/');
+        $fullPath = ABSPATH . '/wp-includes/theme-compat/' . trim($fileName, '/');
         $dir = dirname($fullPath);
 
         if (!is_dir($dir)) {
@@ -75,6 +75,8 @@ abstract class TemplatesTestCase extends ProviderTestCase
         touch($fullPath);
 
         $this->stubFiles[] = $fullPath;
+
+        return realpath($fullPath);
     }
 
     protected function tearDown()

--- a/lib/Test/bootstrap.php
+++ b/lib/Test/bootstrap.php
@@ -4,11 +4,13 @@ use RmpUp\WpDi\Test\Mirror;
 
 const MY_PLUGIN_DIR = __DIR__;
 
-class_alias(Mirror::class, '\\SomeThing');
+class_alias(Mirror::class, '\\MyOwnActionListener');
 class_alias(Mirror::class, '\\MyOwnCliCommand');
 class_alias(Mirror::class, '\\MyOwnFilterHandler');
-class_alias(Mirror::class, '\\MyOwnActionListener');
 class_alias(Mirror::class, '\\MyOwnPostType');
+class_alias(Mirror::class, '\\MyOwnShortcode');
+
+class_alias(Mirror::class, '\\SomeThing');
 class_alias(Mirror::class, '\\WP_CLI');
 
 // Tell wp-integration-test where to find WP


### PR DESCRIPTION
YAML files are a common way to define services.
By now we only have PHP-files/-arrays to define
each service/template.
With this commit it is also possible to parse YAML
files.