### PR TITLE
qa: Test against WordPress 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,19 +23,26 @@ env:
     - WP_VERSION=5.0.*
     - WP_VERSION=5.2.*
     - WP_VERSION=5.4.*
+    - WP_VERSION=5.5.*
     - WP_VERSION=dev-master
 
 matrix:
   include:
-    # additional combination among env (as above)
-    - php: '5.6'
-      env: WP_VERSION=4.8.*
     # Intermediate version tests due to unstable SemVer
     #- php: '7.1'
     #  env: WP_VERSION=4.9
+    # additional combination among env (as above)
+    - php: '5.6'
+      env: WP_VERSION=4.8.*
+    - php: 'hhvm'
+      env: WP_VERSION=5.4.*
+    - php: 'nightly'
+      env: WP_VERSION=5.4.*
   # in the process to achieve support
   allow_failures:
     - php: '5.6'
+    - php: 'hhvm'
+    - php: 'nightly'
     - env: WP_VERSION=dev-master
   # Do not wait for allowed failures
   fast_finish: true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![](https://img.shields.io/badge/PHP-7.0%20--%207.4-blue?style=for-the-badge&logo=php)
-![](https://img.shields.io/badge/WordPress-4.8%20--%205.4-blue?style=for-the-badge&logo=wordpress)
+![](https://img.shields.io/badge/WordPress-4.8%20--%205.5-blue?style=for-the-badge&logo=wordpress)
 
 [![Build Status](https://travis-ci.org/rmp-up/wp-di.svg?branch=master)](https://travis-ci.org/rmp-up/wp-di)
 [![Coverage Status](https://coveralls.io/repos/github/rmp-up/wp-di/badge.svg?branch=master)](https://coveralls.io/github/rmp-up/wp-di?branch=master)


### PR DESCRIPTION
We already test against the nightly builds / dev-master
of WordPress.
Since the release of WP 5.5 we want to explicitly
check against the latest patch of this minor version.

* .travis.yml: Also checking against HHVM
  and PHP nightly which is 8.0-dev right now,
  to unveil upcoming compatibility issues