### PR TITLE
Provider tree

### DIFF
--- a/lib/Provider.php
+++ b/lib/Provider.php
@@ -127,7 +127,7 @@ class Provider implements ServiceProviderInterface
             'services' => new Services(),
             'options' => Options::class,
             'parameters' => new Parameters(),
-            'templates' => Templates::class,
+            'templates' => new Templates(),
         ];
     }
 

--- a/lib/Provider.php
+++ b/lib/Provider.php
@@ -126,7 +126,7 @@ class Provider implements ServiceProviderInterface
         return [
             'services' => new Services(),
             'options' => Options::class,
-            'parameters' => Parameters::class,
+            'parameters' => new Parameters(),
             'templates' => Templates::class,
         ];
     }

--- a/lib/Provider.php
+++ b/lib/Provider.php
@@ -125,7 +125,7 @@ class Provider implements ServiceProviderInterface
     {
         return [
             'services' => new Services(),
-            'options' => Options::class,
+            'options' => new Options(),
             'parameters' => new Parameters(),
             'templates' => new Templates(),
         ];

--- a/lib/Provider/Parameters.php
+++ b/lib/Provider/Parameters.php
@@ -31,14 +31,19 @@ use Pimple\ServiceProviderInterface;
  *
  * @copyright 2020 Pretzlaw (https://rmp-up.de)
  */
-class Parameters implements ServiceProviderInterface
+class Parameters implements ServiceProviderInterface, ProviderNode
 {
     /**
      * @var array
      */
     private $parameters;
 
-    public function __construct(array $parameters)
+    /**
+     * Parameters constructor.
+     *
+     * @param array $parameters (DEPRECATED)
+     */
+    public function __construct(array $parameters = [])
     {
         $this->parameters = $parameters;
     }
@@ -50,10 +55,16 @@ class Parameters implements ServiceProviderInterface
      * It should not get services.
      *
      * @param Container $pimple A container instance
+     * @deprecated 0.8.0 Use ::__invoke instead
      */
     public function register(Container $pimple)
     {
-        foreach ($this->parameters as $parameterName => $value) {
+        $this->__invoke($this->parameters, $pimple);
+    }
+
+    public function __invoke(array $definition, Container $pimple, $key = '')
+    {
+        foreach ($definition as $parameterName => $value) {
             $pimple->offsetSet('%' . $parameterName . '%', $value);
         }
     }

--- a/lib/Provider/ProviderNode.php
+++ b/lib/Provider/ProviderNode.php
@@ -1,0 +1,35 @@
+<?php
+/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
+
+/**
+ * ParserNode.php
+ *
+ * LICENSE: This source file is created by the company around M. Pretzlaw
+ * located in Germany also known as rmp-up. All its contents are proprietary
+ * and under german copyright law. Consider this file as closed source and/or
+ * without the permission to reuse or modify its contents.
+ * This license is available through the world-wide-web at the following URI:
+ * https://rmp-up.de/license-generic.txt . If you did not receive a copy
+ * of the license and are unable to obtain it through the web, please send a
+ * note to mail@rmp-up.de so we can mail you a copy.
+ *
+ * @package   wp-di
+ * @copyright 2020 Pretzlaw
+ * @license   https://rmp-up.de/license-generic.txt
+ */
+
+declare(strict_types=1);
+
+namespace RmpUp\WpDi\Provider;
+
+use Pimple\Container;
+
+/**
+ * ParserNode
+ *
+ * @copyright 2020 Pretzlaw (https://rmp-up.de)
+ */
+interface ProviderNode
+{
+    public function __invoke(array $definition, Container $pimple, $key = '');
+}

--- a/lib/Provider/ProviderNodeTrait.php
+++ b/lib/Provider/ProviderNodeTrait.php
@@ -1,0 +1,68 @@
+<?php
+/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
+
+/**
+ * ParserNode.php
+ *
+ * LICENSE: This source file is created by the company around M. Pretzlaw
+ * located in Germany also known as rmp-up. All its contents are proprietary
+ * and under german copyright law. Consider this file as closed source and/or
+ * without the permission to reuse or modify its contents.
+ * This license is available through the world-wide-web at the following URI:
+ * https://rmp-up.de/license-generic.txt . If you did not receive a copy
+ * of the license and are unable to obtain it through the web, please send a
+ * note to mail@rmp-up.de so we can mail you a copy.
+ *
+ * @package   wp-di
+ * @copyright 2020 Pretzlaw
+ * @license   https://rmp-up.de/license-generic.txt
+ */
+
+declare(strict_types=1);
+
+namespace RmpUp\WpDi\Provider;
+
+use DomainException;
+use Pimple\Container;
+
+/**
+ * ParserNode
+ *
+ * @copyright 2020 Pretzlaw (https://rmp-up.de)
+ */
+trait ProviderNodeTrait
+{
+    /**
+     * @var ProviderNode[][]
+     */
+    protected $nodes = [];
+
+    public function addProvider($key, ProviderNode $node) {
+        if (false === array_key_exists($key, $this->nodes)) {
+            $this->nodes[$key] = [];
+        }
+
+        $this->nodes[$key][] = $node;
+    }
+
+    protected function validateDefinition($definition)
+    {
+        $missing = array_diff_key($this->nodes, $definition);
+
+        if ([] !== $missing) {
+            throw new DomainException(sprintf('Unknown sections: "%s"', implode('", "', array_keys($missing))));
+        }
+    }
+
+    public function __invoke(array $definition, Container $pimple, $key = '')
+    {
+        foreach (array_intersect_key($this->nodes, $definition) as $section => $extensions) {
+            // Found keywords will be forwarded to their handler.
+            // Cast to array in case one key maps directly to one compiler (instead of an array of compiler).
+            foreach ((array) $extensions as $extension) {
+                // Handler receive the specific config but also the general container for further processing.
+                $extension($definition[$key], $pimple, $section);
+            }
+        }
+    }
+}


### PR DESCRIPTION
The current provider all work on their own which causes lots of duplicate code.
The provider can be seen as a tree just like the config (e.g. YAML) so we build a tree-like structure with traits and interfaces,
to allow reducing the duplicate code.