### PR TITLE
Removing some PSR-11 compat

### DIFF
--- a/lib/Compiler/Filter.php
+++ b/lib/Compiler/Filter.php
@@ -67,10 +67,12 @@ class Filter implements CompilerInterface
 
     /**
      * @param string                  $filterName
-     * @param \Pimple\Psr11\Container $container
+     * @param \Pimple\Psr11\Container $container (DEPRECATED 0.8 - Will use Pimple container instead)
      * @param string                  $serviceName
      * @param string[]|null           $methodNames
      * @param int                     $priority
+     *
+     * @deprecated 0.8.0 Will become private
      */
     protected function register($filterName, \Pimple\Psr11\Container $container, string $serviceName, $methodNames, $priority)
     {

--- a/lib/Compiler/WpCli.php
+++ b/lib/Compiler/WpCli.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 namespace RmpUp\WpDi\Compiler;
 
 use Pimple\Container;
-use RmpUp\WpDi\LazyService;
+use RmpUp\WpDi\Helper\LazyPimple;
 use RmpUp\WpDi\Provider\Services;
 use RmpUp\WpDi\Provider\WordPress\CliCommands;
 
@@ -54,8 +54,6 @@ class WpCli implements CompilerInterface
             $commandToMethod = [$commandToMethod => null];
         }
 
-        $container = new \Pimple\Psr11\Container($pimple);
-
         foreach ($commandToMethod as $command => $method) {
             if (null === $method) {
                 $method = '__invoke';
@@ -74,7 +72,7 @@ class WpCli implements CompilerInterface
             if ($pimple->offsetExists($serviceName)) {
                 // Command is wired to existing service.
                 /** @noinspection PhpUndefinedMethodInspection */
-                $class::add_command($command, [new LazyService($container, $serviceName), $method]);
+                $class::add_command($command, [new LazyPimple($pimple, $serviceName), $method]);
                 continue;
             }
         }

--- a/lib/Helper/LazyInstantiating.php
+++ b/lib/Helper/LazyInstantiating.php
@@ -26,6 +26,7 @@ namespace RmpUp\WpDi\Helper;
  * Proxy all calls, read and writes to another object
  *
  * @package RmpUp\WpDi\Helper
+ * @deprecated 0.8.0 Will be shifted to LazyPimple
  */
 trait LazyInstantiating
 {

--- a/lib/LazyService.php
+++ b/lib/LazyService.php
@@ -30,6 +30,7 @@ use RmpUp\WpDi\Helper\LazyInstantiating;
  * LazyService
  *
  * @copyright 2020 Pretzlaw (https://rmp-up.de)
+ * @deprecated 0.8.0 Use LazyPimple instead
  */
 class LazyService
 {

--- a/lib/Test/AbstractTestCase.php
+++ b/lib/Test/AbstractTestCase.php
@@ -30,6 +30,7 @@ use Pretzlaw\WPInt\Traits\WordPressTests;
 use ReflectionException;
 use ReflectionObject;
 use RmpUp\Doc\DocParser;
+use RmpUp\WpDi\Helper\LazyPimple;
 use RmpUp\WpDi\LazyService;
 use RmpUp\WpDi\Provider;
 use RmpUp\WpDi\Yaml;
@@ -94,8 +95,7 @@ abstract class AbstractTestCase extends TestCase
 
     protected static function assertLazyService(string $serviceName, $lazyServiceObject)
     {
-        static::assertInstanceOf(LazyService::class, $lazyServiceObject);
-
+        static::assertContains(get_class($lazyServiceObject), [LazyService::class, LazyPimple::class]);
         static::assertEquals($serviceName, self::getField($lazyServiceObject, 'serviceName'));
     }
 

--- a/lib/Test/WordPress/Cli/ServiceDefinitionTest.php
+++ b/lib/Test/WordPress/Cli/ServiceDefinitionTest.php
@@ -72,11 +72,6 @@ use RmpUp\WpDi\Test\ProviderTestCase;
 class ServiceDefinitionTest extends ProviderTestCase
 {
     /**
-     * @var array
-     */
-    private $config;
-
-    /**
      * @param $arguments
      * @param $name
      */


### PR DESCRIPTION
Currently some classes support the usage of
PSR-11 container.
Besides that all internal logic is heavily based
on Pimple since the first days
which renders the PSR-11 compatibility obsolete.
We carve this compat out whenever found.

* Also marked further remainders as deprecated
  for version 0.8.0