### PR TITLE
tags: Translate in YAML

### DIFF
--- a/lib/Compiler/Yaml/Translate.php
+++ b/lib/Compiler/Yaml/Translate.php
@@ -2,7 +2,7 @@
 /* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
 
 /**
- * OptionNode.php
+ * Translate.php
  *
  * LICENSE: This source file is created by the company around M. Pretzlaw
  * located in Germany also known as rmp-up. All its contents are proprietary
@@ -20,37 +20,29 @@
 
 declare(strict_types=1);
 
-namespace RmpUp\WpDi\ServiceDefinition;
+namespace RmpUp\WpDi\Compiler\Yaml;
+
+use RmpUp\WpDi\Helper\WordPress\LazyFunctionCall;
+use RmpUp\WpDi\Yaml;
+use Symfony\Component\Yaml\Tag\TaggedValue;
 
 /**
- * OptionNode
+ * Translate
  *
  * @copyright 2020 Pretzlaw (https://rmp-up.de)
  */
-class OptionNode extends AbstractNode
+class Translate implements YamlCompiler
 {
-    /**
-     * @see get_option()
-     */
-    const DEFAULT = false;
-    /**
-     * @var mixed
-     */
-    private $default;
-
-    /**
-     * @var string
-     */
-    private $optionName;
-
-    public function __construct(string $optionName, $default = self::DEFAULT)
+    public function __invoke(TaggedValue $taggedValue)
     {
-        $this->optionName = $optionName;
-        $this->default = $default;
-    }
+        $definition = (array) $taggedValue->getValue();
 
-    public function __invoke()
-    {
-        return get_option($this->optionName, $this->wakeup($this->default));
+        if (false === is_callable($taggedValue->getTag())) {
+            throw new \InvalidArgumentException(
+                'Translate handler bound to non-callable - please only use existing functions/callables'
+            );
+        }
+
+        return new LazyFunctionCall($taggedValue->getTag(), ...$definition);
     }
 }

--- a/lib/Helper/LazyInvoke.php
+++ b/lib/Helper/LazyInvoke.php
@@ -2,7 +2,7 @@
 /* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
 
 /**
- * OptionNode.php
+ * LazyInvoke.php
  *
  * LICENSE: This source file is created by the company around M. Pretzlaw
  * located in Germany also known as rmp-up. All its contents are proprietary
@@ -20,37 +20,9 @@
 
 declare(strict_types=1);
 
-namespace RmpUp\WpDi\ServiceDefinition;
+namespace RmpUp\WpDi\Helper;
 
-/**
- * OptionNode
- *
- * @copyright 2020 Pretzlaw (https://rmp-up.de)
- */
-class OptionNode extends AbstractNode
+interface LazyInvoke
 {
-    /**
-     * @see get_option()
-     */
-    const DEFAULT = false;
-    /**
-     * @var mixed
-     */
-    private $default;
-
-    /**
-     * @var string
-     */
-    private $optionName;
-
-    public function __construct(string $optionName, $default = self::DEFAULT)
-    {
-        $this->optionName = $optionName;
-        $this->default = $default;
-    }
-
-    public function __invoke()
-    {
-        return get_option($this->optionName, $this->wakeup($this->default));
-    }
+    public function __invoke();
 }

--- a/lib/Helper/WordPress/LazyFunctionCall.php
+++ b/lib/Helper/WordPress/LazyFunctionCall.php
@@ -2,7 +2,7 @@
 /* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
 
 /**
- * OptionNode.php
+ * LazyTranslation.php
  *
  * LICENSE: This source file is created by the company around M. Pretzlaw
  * located in Germany also known as rmp-up. All its contents are proprietary
@@ -20,37 +20,40 @@
 
 declare(strict_types=1);
 
-namespace RmpUp\WpDi\ServiceDefinition;
+namespace RmpUp\WpDi\Helper\WordPress;
+
+use RmpUp\WpDi\Helper\LazyInvoke;
 
 /**
- * OptionNode
+ * LazyTranslation
  *
  * @copyright 2020 Pretzlaw (https://rmp-up.de)
  */
-class OptionNode extends AbstractNode
+class LazyFunctionCall implements LazyInvoke
 {
     /**
-     * @see get_option()
+     * @var array
      */
-    const DEFAULT = false;
+    private $arguments;
     /**
-     * @var mixed
+     * @var callable
      */
-    private $default;
+    private $callable;
 
     /**
-     * @var string
+     * LazyFunctionCall constructor.
+     *
+     * @param callable $callable
+     * @param mixed    ...$arguments
      */
-    private $optionName;
-
-    public function __construct(string $optionName, $default = self::DEFAULT)
+    public function __construct($callable, ...$arguments)
     {
-        $this->optionName = $optionName;
-        $this->default = $default;
+        $this->callable = $callable;
+        $this->arguments = $arguments;
     }
 
     public function __invoke()
     {
-        return get_option($this->optionName, $this->wakeup($this->default));
+        return (($this->callable)(...$this->arguments));
     }
 }

--- a/lib/Helper/Yaml/Implode.php
+++ b/lib/Helper/Yaml/Implode.php
@@ -2,7 +2,7 @@
 /* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
 
 /**
- * OptionNode.php
+ * Implode.php
  *
  * LICENSE: This source file is created by the company around M. Pretzlaw
  * located in Germany also known as rmp-up. All its contents are proprietary
@@ -20,37 +20,40 @@
 
 declare(strict_types=1);
 
-namespace RmpUp\WpDi\ServiceDefinition;
+namespace RmpUp\WpDi\Helper\Yaml;
+
+use RmpUp\WpDi\Helper\LazyInvoke;
 
 /**
- * OptionNode
+ * Implode
  *
  * @copyright 2020 Pretzlaw (https://rmp-up.de)
  */
-class OptionNode extends AbstractNode
+class Implode implements LazyInvoke
 {
-    /**
-     * @see get_option()
-     */
-    const DEFAULT = false;
-    /**
-     * @var mixed
-     */
-    private $default;
-
+    private $parts;
     /**
      * @var string
      */
-    private $optionName;
+    private $seperator;
 
-    public function __construct(string $optionName, $default = self::DEFAULT)
+    public function __construct(string $seperator, $parts)
     {
-        $this->optionName = $optionName;
-        $this->default = $default;
+        $this->parts = $parts;
+        $this->seperator = $seperator;
     }
 
     public function __invoke()
     {
-        return get_option($this->optionName, $this->wakeup($this->default));
+        $parsedParts = [];
+        foreach ($this->parts as $part) {
+            if ($part instanceof LazyInvoke) {
+                $part = $part();
+            }
+
+            $parsedParts[] = $part;
+        }
+
+        return implode($this->seperator, $parsedParts);
     }
 }

--- a/lib/Provider/WordPress/Templates.php
+++ b/lib/Provider/WordPress/Templates.php
@@ -71,7 +71,6 @@ class Templates implements ServiceProviderInterface, ProviderNode
         foreach ($definition as $templateName => $templates) {
             if (is_int($templateName) && is_string($templates)) {
                 $templateName = $templates;
-                $templates = (array) $templates;
             }
 
             if ($templates instanceof Closure) {
@@ -80,7 +79,11 @@ class Templates implements ServiceProviderInterface, ProviderNode
                 continue;
             }
 
-            $templateNode = new TemplateNode((array) $templates);
+            if (false === is_array($templates)) {
+                $templates = [$templates];
+            }
+
+            $templateNode = new TemplateNode($templates);
 
             $pimple[$templateName] = $templateNode; // @deprecated 0.8.0
             $pimple['%' . $templateName . '%'] = $templateNode;

--- a/lib/ServiceDefinition.php
+++ b/lib/ServiceDefinition.php
@@ -25,6 +25,7 @@ namespace RmpUp\WpDi;
 use ArrayObject;
 use Pimple\Container;
 use RmpUp\WpDi\Helper\Check;
+use RmpUp\WpDi\Helper\LazyInvoke;
 use RmpUp\WpDi\Helper\LazyPimple;
 use RmpUp\WpDi\Provider\Services;
 
@@ -64,6 +65,10 @@ class ServiceDefinition extends ArrayObject
 
             if (is_string($argument)) {
                 $this[Services::ARGUMENTS][$key] = $this->resolveParameter($pimple, $argument);
+            }
+
+            if ($argument instanceof LazyInvoke) {
+                $this[Services::ARGUMENTS][$key] = $argument();
             }
         }
 

--- a/lib/ServiceDefinition/AbstractNode.php
+++ b/lib/ServiceDefinition/AbstractNode.php
@@ -2,7 +2,7 @@
 /* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
 
 /**
- * OptionNode.php
+ * AbstractNode.php
  *
  * LICENSE: This source file is created by the company around M. Pretzlaw
  * located in Germany also known as rmp-up. All its contents are proprietary
@@ -22,35 +22,21 @@ declare(strict_types=1);
 
 namespace RmpUp\WpDi\ServiceDefinition;
 
+use RmpUp\WpDi\Helper\LazyInvoke;
+
 /**
- * OptionNode
+ * AbstractNode
  *
  * @copyright 2020 Pretzlaw (https://rmp-up.de)
  */
-class OptionNode extends AbstractNode
+abstract class AbstractNode
 {
-    /**
-     * @see get_option()
-     */
-    const DEFAULT = false;
-    /**
-     * @var mixed
-     */
-    private $default;
-
-    /**
-     * @var string
-     */
-    private $optionName;
-
-    public function __construct(string $optionName, $default = self::DEFAULT)
+    protected function wakeup($value)
     {
-        $this->optionName = $optionName;
-        $this->default = $default;
-    }
+        if ($value instanceof LazyInvoke) {
+            $value = $value();
+        }
 
-    public function __invoke()
-    {
-        return get_option($this->optionName, $this->wakeup($this->default));
+        return $value;
     }
 }

--- a/lib/ServiceDefinition/TemplateNode.php
+++ b/lib/ServiceDefinition/TemplateNode.php
@@ -22,17 +22,19 @@ declare(strict_types=1);
 
 namespace RmpUp\WpDi\ServiceDefinition;
 
+use RmpUp\WpDi\Helper\LazyInvoke;
+
 /**
  * TemplateNode
  *
  * @copyright 2020 Pretzlaw (https://rmp-up.de)
  */
-class TemplateNode
+class TemplateNode extends AbstractNode
 {
     /**
      * All possible locations
      *
-     * @var array
+     * @var string[]|LazyInvoke[]
      */
     private $templates;
 
@@ -60,6 +62,8 @@ class TemplateNode
     {
         $templatePath = '';
         foreach ($this->templates as $templatePath) {
+            $templatePath = $this->wakeup($templatePath);
+
             $located = locate_template($templatePath, false, false);
 
             if ('' !== $located) {

--- a/lib/Test/Primitives/YamlExpressions/Translations/JoinContainingTranslationsTest.php
+++ b/lib/Test/Primitives/YamlExpressions/Translations/JoinContainingTranslationsTest.php
@@ -1,0 +1,71 @@
+<?php
+/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
+
+/**
+ * JoinContainingTranslationsTest.php
+ *
+ * LICENSE: This source file is created by the company around M. Pretzlaw
+ * located in Germany also known as rmp-up. All its contents are proprietary
+ * and under german copyright law. Consider this file as closed source and/or
+ * without the permission to reuse or modify its contents.
+ * This license is available through the world-wide-web at the following URI:
+ * https://rmp-up.de/license-generic.txt . If you did not receive a copy
+ * of the license and are unable to obtain it through the web, please send a
+ * note to mail@rmp-up.de so we can mail you a copy.
+ *
+ * @package   wp-di
+ * @copyright 2020 Pretzlaw
+ * @license   https://rmp-up.de/license-generic.txt
+ */
+
+declare(strict_types=1);
+
+namespace RmpUp\WpDi\Test\Primitives\YamlExpressions\Translations;
+
+use RmpUp\WpDi\Helper\LazyInvoke;
+use RmpUp\WpDi\Helper\WordPress\LazyFunctionCall;
+use RmpUp\WpDi\Helper\Yaml\Implode;
+use RmpUp\WpDi\Test\AbstractTestCase;
+
+/**
+ * Translations can also be
+ * inside a `!join` tag for example
+ * and still preserve their laziness:
+ *
+ * ```yaml
+ * services:
+ *   SomeThing:
+ *     arguments:
+ *       - !join [ !__ [ "Hello", "foo" ] , " there!" ]
+ * ```
+ *
+ * In this example "Hello" will be translated (using the textdomain `foo`)
+ * and then "World!" will be appended (by the `!join` tag).
+ * Not while parsing the YAML but as soon as the service is used.
+ *
+ * @copyright 2020 Pretzlaw (https://rmp-up.de)
+ */
+class JoinContainingTranslationsTest extends AbstractTestCase
+{
+    /**
+     * @return mixed|LazyFunctionCall
+     */
+    private function getFirstParameter()
+    {
+        return $this->yaml(0, 'services', 'SomeThing', 'arguments', 0);
+    }
+
+    public function testJoinKeptLazy()
+    {
+        static::assertFalse(is_string($this->getFirstParameter()));
+    }
+
+    public function testSomeThingHasFullConcatenatedTranslation()
+    {
+        $lazyFunction = $this->getFirstParameter();
+
+        static::assertInstanceOf(LazyInvoke::class, $lazyFunction);
+        static::assertInstanceOf(Implode::class, $lazyFunction);
+        static::assertEquals('Hello there!', $lazyFunction());
+    }
+}

--- a/lib/Test/Primitives/YamlExpressions/TranslationsTest.php
+++ b/lib/Test/Primitives/YamlExpressions/TranslationsTest.php
@@ -1,0 +1,75 @@
+<?php
+/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
+
+/**
+ * TranslationsTest.php
+ *
+ * LICENSE: This source file is created by the company around M. Pretzlaw
+ * located in Germany also known as rmp-up. All its contents are proprietary
+ * and under german copyright law. Consider this file as closed source and/or
+ * without the permission to reuse or modify its contents.
+ * This license is available through the world-wide-web at the following URI:
+ * https://rmp-up.de/license-generic.txt . If you did not receive a copy
+ * of the license and are unable to obtain it through the web, please send a
+ * note to mail@rmp-up.de so we can mail you a copy.
+ *
+ * @package   wp-di
+ * @copyright 2020 Pretzlaw
+ * @license   https://rmp-up.de/license-generic.txt
+ */
+
+declare(strict_types=1);
+
+namespace RmpUp\WpDi\Test\Primitives\YamlExpressions;
+
+use RmpUp\WpDi\Helper\WordPress\LazyFunctionCall;
+use RmpUp\WpDi\Test\Mirror;
+use RmpUp\WpDi\Test\Primitives\YamlExpressionsTest;
+use SomeThing;
+
+/**
+ * Translations within Yaml
+ *
+ * For a few scenarios in WordPress it is necessary to translate
+ * titles, menu-entries and other things.
+ * The common functions `__()`, `_n()` and other
+ * are available within YAML like this:
+ *
+ * ```yaml
+ * services:
+ *   SomeThing:
+ *     arguments:
+ *       - !__ [ Wer ist Adam?, dark ]
+ *       # Same as `__('Wer ist Adam?', 'dark')` but lazy
+ * ```
+ *
+ * Those translations won't be applied immediately.
+ * They are lazy until the service is needed
+ * to spare some runtime.
+ *
+ * @copyright 2020 Pretzlaw (https://rmp-up.de)
+ */
+class TranslationsTest extends YamlExpressionsTest
+{
+    public function testTranslationIsLazy()
+    {
+        $arguments = $this->yaml(0, 'services', 'SomeThing', 'arguments');
+
+        static::assertInstanceOf(LazyFunctionCall::class, current($arguments));
+    }
+
+    public function testIsTranslatedWithinContainer()
+    {
+        $this->mockFilter('gettext')
+            ->expects($this->atLeastOnce())
+            ->with('Wer ist Adam?', 'Wer ist Adam?', 'dark')
+            ->willReturn('Nicht Eva!');
+
+        $this->registerServices();
+
+        /** @var Mirror $thing */
+        $thing = $this->container->get(SomeThing::class);
+
+        static::assertEquals('Nicht Eva!', $thing->getConstructorArgs()[0]);
+    }
+}


### PR DESCRIPTION
Meta-Boxes, Post-Types and other
can be registered using wp-di.
But this is only possible in one language
or with immediate translations that cost
some performance.
Some common WordPress translation functions
have been added as YAML-Tags.

* Translations/Tags work in a lazy way
* Join has become lazy too
  to allow nesting of lazy tags.