### PR TITLE
services: Using a custom factory to create a service

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Define services as known from classical DI but also ...
 * Default values for options
 * Path to templates
 * Inject all of them into services
+* Allow factories to create services
 
 ```yaml
 # Primitive parameters as usual

--- a/lib/Test/Services/Factory/FactoryWithArgumentsTest.php
+++ b/lib/Test/Services/Factory/FactoryWithArgumentsTest.php
@@ -1,0 +1,70 @@
+<?php
+/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
+
+/**
+ * FactoryWithArgumentsTest.php
+ *
+ * LICENSE: This source file is created by the company around M. Pretzlaw
+ * located in Germany also known as rmp-up. All its contents are proprietary
+ * and under german copyright law. Consider this file as closed source and/or
+ * without the permission to reuse or modify its contents.
+ * This license is available through the world-wide-web at the following URI:
+ * https://rmp-up.de/license-generic.txt . If you did not receive a copy
+ * of the license and are unable to obtain it through the web, please send a
+ * note to mail@rmp-up.de so we can mail you a copy.
+ *
+ * @package   wp-di
+ * @copyright 2020 Pretzlaw
+ * @license   https://rmp-up.de/license-generic.txt
+ */
+
+declare(strict_types=1);
+
+namespace RmpUp\WpDi\Test\Services\Factory;
+
+use RmpUp\WpDi\Test\AbstractTestCase;
+use SomeThing;
+
+/**
+ * Using arguments
+ *
+ * ```yaml
+ * parameters:
+ *   line: wand
+ *   circle: stone
+ *   triangle: cloak
+ *
+ * services:
+ *   MyFactory: ~
+ *
+ *   SomeThing:
+ *     factory: "@MyFactory"
+ *     arguments: [ "%line%", "%circle%", "%triangle%", "404 logic not found" ]
+ * ```
+ *
+ * @copyright 2020 Pretzlaw (https://rmp-up.de)
+ */
+class FactoryWithArgumentsTest extends AbstractTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->registerServices();
+    }
+
+    public function testFactoryUsingArguments()
+    {
+        static::assertEquals('@MyFactory', $this->pimple->raw('SomeThing')['factory']);
+
+        $result = $this->pimple[SomeThing::class];
+        static::assertNotInstanceOf(SomeThing::class, $result);
+
+        // Proofs that SomeThing::__invoke has been called
+        // due to how the Mirror::__invoke works.
+        static::assertEquals(
+            ['wand', 'stone', 'cloak', '404 logic not found'],
+            $result['invoked']
+        );
+    }
+}

--- a/lib/Test/Services/FactoryTest.php
+++ b/lib/Test/Services/FactoryTest.php
@@ -1,0 +1,62 @@
+<?php
+/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
+
+/**
+ * Factory.php
+ *
+ * LICENSE: This source file is created by the company around M. Pretzlaw
+ * located in Germany also known as rmp-up. All its contents are proprietary
+ * and under german copyright law. Consider this file as closed source and/or
+ * without the permission to reuse or modify its contents.
+ * This license is available through the world-wide-web at the following URI:
+ * https://rmp-up.de/license-generic.txt . If you did not receive a copy
+ * of the license and are unable to obtain it through the web, please send a
+ * note to mail@rmp-up.de so we can mail you a copy.
+ *
+ * @package   wp-di
+ * @copyright 2020 Pretzlaw
+ * @license   https://rmp-up.de/license-generic.txt
+ */
+
+declare(strict_types=1);
+
+namespace RmpUp\WpDi\Test\Services;
+
+use RmpUp\WpDi\Provider\Services;
+use RmpUp\WpDi\ServiceDefinition;
+use RmpUp\WpDi\Test\AbstractTestCase;
+use SomeThingElse;
+
+/**
+ * Factory
+ *
+ * ```yaml
+ * services:
+ *   MyFactory: ~
+ *
+ *   SomeThingElse:
+ *     factory: "@MyFactory"
+ * ```
+ *
+ * @copyright 2020 Pretzlaw (https://rmp-up.de)
+ */
+class FactoryTest extends AbstractTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->registerServices();
+    }
+
+    public function testDefinition()
+    {
+        static::assertInstanceOf(ServiceDefinition::class, $this->pimple->raw(SomeThingElse::class));
+
+        $result = $this->pimple[SomeThingElse::class];
+
+        // Invoked MyFactory with nothing
+        static::assertNotInstanceOf(SomeThingElse::class, $result);
+        static::assertEquals([], $result['invoked']);
+    }
+}

--- a/lib/Test/bootstrap.php
+++ b/lib/Test/bootstrap.php
@@ -44,6 +44,7 @@ class MyOwnWidget extends \WP_Widget {
 }
 
 class_alias(Mirror::class, '\\MyBox');
+class_alias(Mirror::class, '\\MyFactory');
 class_alias(Mirror::class, '\\MyOwnActionListener');
 class_alias(Mirror::class, '\\MyOwnCliCommand');
 class_alias(Mirror::class, '\\MyOwnFilterHandler');


### PR DESCRIPTION
Services are defined naming a class
and its constructor arguments.
This makes it almost impossible to react to the environment
which may cause a service to have a different state per system state.
Generating services/objects depending on the environment
can be done using factories.

* services: Create service using a factory
* services: Call factory with given (referenced) arguments
* README.md: Only name the possibility but not overload the example
             with such "complex" topic.