### PR TITLE
qa: Watch failing mutants via infection/infection

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -5,10 +5,14 @@ HTTPD__DocumentRoot=/var/www/srv
 HTTPD_a2enmod=rewrite
 PHP__memory_limit=512M
 PHP__session.save_path=/var/www/var/sessions
-PHP__xdebug.remote_host=10.210.9.1
+
+PHP__xdebug.client_host=10.210.9.1
 PHP__xdebug.idekey=PHPSTORM
+PHP__xdebug.mode=coverage,debug
+
+PHP__xdebug.remote_host=10.210.9.1
 PHP__xdebug.remote_enable=1
-PHP__xdebug.remote_autostart=1
 PHP__xdebug.profiler_enable_trigger=1
-PHP_php5enmod=mysqli xdebug zip xhprof
 PHP_IDE_CONFIG=serverName=php
+
+PHP_php5enmod=mysqli xdebug zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,10 +97,12 @@ install:
 
 script:
   - "[[ $WP_VERSION == *'dev-master' ]] || composer validate --strict --no-check-lock"
-  - vendor/bin/phpunit -c etc/phpunit/phpunit.xml.dist --coverage-clover coverage.xml
-  # Code quality checks should not differ among different PHP versions, so we spare runtime here
-  - "[[ $TRAVIS_PHP_VERSION != 7.3 ]] || vendor/bin/phpstan analyse -c etc/phpstan/phpstan.neon.dist lib/"
-  - "[[ $TRAVIS_PHP_VERSION != 7.3 ]] || vendor/bin/phpcs --standard=etc/phpcs/phpcs.xml.dist -s lib/"
+  - composer phpunit
+  # Code quality checks should not differ among different PHP versions
+  # We spare runtime here by spreading them across versions
+  - "[[ $TRAVIS_PHP_VERSION != 7.2 ]] || composer phpcs"
+  - "[[ $TRAVIS_PHP_VERSION != 7.3 ]] || composer phpstan"
+  - "[[ $TRAVIS_PHP_VERSION != 7.4 ]] || composer infection"
 
 after_success:
   - composer bin php-coveralls require php-coveralls/php-coveralls

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   "require-dev": {
     "php": "7.0 - 7.4 || 8.0.*",
     "bamarni/composer-bin-plugin": "^1.4",
-    "johnpbloch/wordpress": "5.2.*",
+    "johnpbloch/wordpress": "5.6.*",
     "perftools/php-profiler": "0.12.*",
     "roave/security-advisories": "dev-master"
   },
@@ -43,11 +43,17 @@
   "scripts": {
     "post-install-cmd": [
       "test -h srv/wp-content/plugins/wp-di || ln -sr opt/wp-di srv/wp-content/plugins/",
-      "@composer bin all install --ansi"
+      "@composer bin all install --ansi",
+      "vendor/bin/wp --allow-root core config --force"
     ],
     "post-update-cmd": [
       "test -h srv/wp-content/plugins/wp-di || ln -sr opt/wp-di srv/wp-content/plugins/",
-      "@composer bin all install --ansi"
-    ]
+      "@composer bin all install --ansi",
+      "vendor/bin/wp --allow-root core config --force"
+    ],
+    "infection": "vendor/bin/infection --configuration=etc/phpunit/infection.json.dist --threads=8",
+    "phpcs": "vendor/bin/phpcs --standard=etc/phpcs/phpcs.xml.dist -s lib/",
+    "phpstan": "vendor/bin/phpstan analyse -c etc/phpstan/phpstan.neon.dist lib/",
+    "phpunit": "vendor/bin/phpunit -c etc/phpunit/phpunit.xml.dist --coverage-clover coverage.xml"
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,16 @@
 version: '3'
 
 services:
+  php74:
+    image: pretzlaw/php:7.4-apache
+    volumes:
+      - ".:/var/www"
+      - "$COMPOSER_LOCAL:/var/composer"
+    env_file: [ .env ]
+#    networks:
+#      default:
+#        ipv4_address: 10.210.9.74
+
   php73:
     image: pretzlaw/php:7.3-apache
     volumes:
@@ -22,7 +32,7 @@ services:
         ipv4_address: 10.210.9.10
 
   php70:
-    image: pretzlaw/php:7.0-fpm
+    image: pretzlaw/php:7.0-apache
     volumes:
       - ".:/var/www"
       - "$COMPOSER_LOCAL:/var/composer"

--- a/etc/phpunit/composer.json
+++ b/etc/phpunit/composer.json
@@ -1,5 +1,6 @@
 {
   "require-dev": {
+    "infection/infection": "0.*",
     "php-mock/php-mock": "^2.3",
     "phpunit/phpunit": "6.* || 7.* || 8.* || 9.*",
     "pretzlaw/wp-integration-test": "0.4.0-rc.2",

--- a/etc/phpunit/infection.json.dist
+++ b/etc/phpunit/infection.json.dist
@@ -1,0 +1,24 @@
+{
+  "source": {
+    "directories": [
+      "lib"
+    ]
+  },
+  "timeout": 4,
+  "logs": {
+    "text": "var/infection.log"
+  },
+  "phpUnit": {
+    "configDir": ".",
+    "customPath": "vendor/bin/phpunit"
+  },
+  "mutators": {
+    "@return_value": true,
+    "@sort": true,
+    "@unwrap": true,
+    "@zero_iteration": true,
+    "RoundingFamily": true
+  },
+  "minMsi": 50,
+  "minCoveredMsi": 80
+}

--- a/etc/phpunit/phpunit.xml.dist
+++ b/etc/phpunit/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/7.0/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/9.0/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="../../opt/doc/bootstrap.php"

--- a/opt/doc/Helper/YamlTest.php
+++ b/opt/doc/Helper/YamlTest.php
@@ -1,0 +1,54 @@
+<?php
+/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
+
+/**
+ * YamlTest.php
+ *
+ * LICENSE: This source file is created by the company around M. Pretzlaw
+ * located in Germany also known as rmp-up. All its contents are proprietary
+ * and under german copyright law. Consider this file as closed source and/or
+ * without the permission to reuse or modify its contents.
+ * This license is available through the world-wide-web at the following URI:
+ * https://rmp-up.de/license-generic.txt . If you did not receive a copy
+ * of the license and are unable to obtain it through the web, please send a
+ * note to mail@rmp-up.de so we can mail you a copy.
+ *
+ * @package   wp-di
+ * @copyright 2021 Pretzlaw
+ * @license   https://rmp-up.de/license-generic.txt
+ */
+
+declare(strict_types=1);
+
+namespace RmpUp\WpDi\Test\Helper;
+
+use RmpUp\WpDi\Compiler\Yaml\Join;
+use RmpUp\WpDi\Helper\Yaml\Implode;
+use RmpUp\WpDi\Test\AbstractTestCase;
+use Symfony\Component\Yaml\Tag\TaggedValue;
+
+/**
+ * YamlTest
+ *
+ * @covers \RmpUp\WpDi\Compiler\Yaml\Join::__invoke
+ */
+class YamlTest extends AbstractTestCase
+{
+	/**
+	 * @internal
+	 */
+	public function testSymfonyCompat()
+	{
+		$taggeValue = new TaggedValue('join', [
+				'    Hello',
+				'    World',
+		]);
+
+		$join = new Join();
+
+		/** @var Implode $implode */
+		$implode = $join->__invoke($taggeValue);
+
+		static::assertEquals('    Hello    World', $implode());
+	}
+}

--- a/opt/doc/Services/NamedArgumentsTest.php
+++ b/opt/doc/Services/NamedArgumentsTest.php
@@ -1,0 +1,66 @@
+<?php
+/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
+
+/**
+ * NamedArgumentsTest.php
+ *
+ * LICENSE: This source file is created by the company around M. Pretzlaw
+ * located in Germany also known as rmp-up. All its contents are proprietary
+ * and under german copyright law. Consider this file as closed source and/or
+ * without the permission to reuse or modify its contents.
+ * This license is available through the world-wide-web at the following URI:
+ * https://rmp-up.de/license-generic.txt . If you did not receive a copy
+ * of the license and are unable to obtain it through the web, please send a
+ * note to mail@rmp-up.de so we can mail you a copy.
+ *
+ * @package   wp-di
+ * @copyright 2021 Pretzlaw
+ * @license   https://rmp-up.de/license-generic.txt
+ */
+
+declare(strict_types=1);
+
+namespace RmpUp\WpDi\Test\Services;
+
+use RmpUp\WpDi\Test\AbstractTestCase;
+use RmpUp\WpDi\Test\Mirror;
+use SomeThing;
+
+/**
+ * NamedArgumentsTest
+ *
+ * ```yaml
+ * services:
+ *   SomeThing:
+ *     arguments:
+ *       first: reunited
+ *       and: it
+ *       feels: good
+ * ```
+ *
+ * @internal
+ */
+class NamedArgumentsTest extends AbstractTestCase
+{
+	protected function compatSetUp()
+	{
+		parent::compatSetUp();
+
+		$this->registerServices();
+	}
+
+	public function testNamedArgumentsAreInjected()
+	{
+		/** @var Mirror $mirror */
+		$mirror = $this->pimple[SomeThing::class];
+
+		static::assertEquals(
+			[
+				'reunited',
+				'it',
+				'good'
+			],
+			$mirror->getConstructorArgs()
+		);
+	}
+}

--- a/opt/doc/Services/UsingCallbacksTest.php
+++ b/opt/doc/Services/UsingCallbacksTest.php
@@ -121,7 +121,7 @@ class UsingCallbacksTest extends AbstractTestCase
         static::assertInstanceOf(ArrayObject::class, $things);
 
         static::assertTrue(is_string($things['string']));
-        static::assertRegExp('/[anis]{4}/', $things['string']);
+        static::assertMatchesRegularExpression('/[anis]{4}/', $things['string']);
 
         static::assertTrue(is_int($things['int']));
         static::assertLessThan(10, $things['int']);


### PR DESCRIPTION
Infection helps covering the code even more,
because it mutates the code a little bit
and reports if the test didn't recognize the change.

* infection.json.dist: introducing one mutator at a time
* qa: Adding infection to CI